### PR TITLE
Use body instead of the non existent res.body

### DIFF
--- a/superlance/httpok.py
+++ b/superlance/httpok.py
@@ -191,7 +191,7 @@ class HTTPOk:
                 if str(status) != str(self.status):
                     subject = 'httpok for %s: bad status returned' % self.url
                     self.act(subject, msg)
-                elif self.inbody and self.inbody not in res.body:
+                elif self.inbody and self.inbody not in body:
                     act = True
                     subject = 'httpok for %s: bad body returned' % self.url
                     self.act(subject, msg)


### PR DESCRIPTION
res.body doesn't exist. The variable is "body". When you start httpok with the -b flag it crashes when it tries to access.
