### PR TITLE
Support query arguments in the URL

### DIFF
--- a/superlance/httpok.py
+++ b/superlance/httpok.py
@@ -142,6 +142,9 @@ class HTTPOk:
         path = parsed[2]
         query = parsed[3]
 
+        if query:
+            path += '?' + query
+
         if self.connclass:
             ConnClass = self.connclass
         elif scheme == 'http':
@@ -165,9 +168,6 @@ class HTTPOk:
 
             conn = ConnClass(hostport)
             conn.timeout = self.timeout
-
-            if query:
-                path += '?' + query
 
             act = False
 


### PR DESCRIPTION
Another typo, urlsplit places the query arguments in the index 3, not 4 (urlparse is the function that places it in index 4).
