### PR TITLE
TimeoutHTTPSConnection fixes, extended option -c

### DIFF
--- a/docs/httpok.rst
+++ b/docs/httpok.rst
@@ -74,13 +74,23 @@ Command-Line Syntax
 
 .. cmdoption:: -c <http_status_code>, --code=<http_status_code>
    
-   Specify the expected HTTP status code for the configured URL.
+   Specify a comma-separated list of expected HTTP status codes for the configured URL.
    
-   If this status code is not the status code provided by the response,
+   If any of these status codes match the status code provided by the response,
    :command:`httpok` will attempt to restart child processes which are
    in the ``RUNNING`` state, and specified by ``-p`` or ``-a``.  
    
-   Defaults to the string, "200".
+   Defaults to the string, "200".  Can't be used in combination with -C.
+   
+.. cmdoption:: -C <http_status_code>, --not-code=<http_status_code>
+   
+   Specify a comma-separated list of unexpected HTTP status codes for the configured URL.
+   
+   If any of these status codes match the status code provided by the response,
+   :command:`httpok` will attempt to restart child processes which are
+   in the ``RUNNING`` state, and specified by ``-p`` or ``-a``.  
+   
+   This can't be used in combination with -c.
 
 .. cmdoption:: -b <body_string>, --body=<body_string>
    

--- a/superlance/httpok.py
+++ b/superlance/httpok.py
@@ -25,8 +25,8 @@
 # events=TICK_60
 
 doc = """\
-httpok.py [-p processname] [-a] [-g] [-t timeout] [-c status_code] [-b inbody]
-          [-m mail_address] [-s sendmail] URL
+httpok.py [-p processname] [-a] [-g] [-t timeout] [-c status_codes]  [-C nstatus_codes] 
+          [-b inbody] [-m mail_address] [-s sendmail] URL
 
 Options:
 
@@ -55,11 +55,17 @@ Options:
       attempt to restart processes in the RUNNING state specified by
       -p or -a.  This defaults to 10 seconds.
 
--c -- specify an expected HTTP status code from a GET request to the
-      URL.  If this status code is not the status code provided by the
-      response, httpok will attempt to restart processes in the
-      RUNNING state specified by -p or -a.  This defaults to the
-      string, "200".
+-c -- specify a comma-separated list of expected HTTP status codes from a 
+      GET request to the URL.  If none of these status codes match the 
+      status code provided by the response, httpok will attempt to restart 
+      processes in the RUNNING state specified by -p or -a.  This defaults 
+      to the string, "200" and can't be used with -C.
+      
+-C -- specify a comma-separated list of unexpected HTTP status codes from a 
+      GET request to the URL.  If any of these status codes match the 
+      status code provided by the response, httpok will attempt to restart 
+      processes in the RUNNING state specified by -p or -a.  This can't be 
+      used with -c.
 
 -b -- specify a string which should be present in the body resulting
       from the GET request.  If this string is not present in the
@@ -112,14 +118,15 @@ def usage():
 
 class HTTPOk:
     connclass = None
-    def __init__(self, rpc, programs, any, url, timeout, status, inbody,
+    def __init__(self, rpc, programs, any, url, timeout, status, nstatus, inbody,
                  email, sendmail, coredir, gcore, eager):
         self.rpc = rpc
         self.programs = programs
         self.any = any
         self.url = url
         self.timeout = timeout
-        self.status = status
+        self.status = status and [str(s).strip() for s in status.split(',')] or []
+        self.nstatus = nstatus and [str(s).strip() for s in nstatus.split(',')] or []
         self.inbody = inbody
         self.email = email
         self.sendmail = sendmail
@@ -187,7 +194,8 @@ class HTTPOk:
                     status = None
                     msg = 'error contacting %s:\n\n %s' % (self.url, why)
 
-                if str(status) != str(self.status):
+                if (self.status and str(status) not in self.status) or \
+                    (self.nstatus and str(status) in self.nstatus):
                     subject = 'httpok for %s: bad status returned' % self.url
                     self.act(subject, msg)
                 elif self.inbody and self.inbody not in body:
@@ -289,13 +297,14 @@ class HTTPOk:
 
 def main(argv=sys.argv):
     import getopt
-    short_args="hp:at:c:b:s:m:g:d:eE"
+    short_args="hp:at:cC:b:s:m:g:d:eE"
     long_args=[
         "help",
         "program=",
         "any",
         "timeout=",
         "code=",
+        "not-code=",
         "body=",
         "sendmail_program=",
         "email=",
@@ -324,6 +333,7 @@ def main(argv=sys.argv):
     email = None
     timeout = 10
     status = '200'
+    nstatus = ''
     inbody = None
 
     for option, value in opts:
@@ -348,6 +358,10 @@ def main(argv=sys.argv):
 
         if option in ('-c', '--code'):
             status = value
+            
+        if option in ('-C', '--not-code'):
+            nstatus = value
+            status = ''
 
         if option in ('-b', '--body'):
             inbody = value
@@ -376,7 +390,7 @@ def main(argv=sys.argv):
         sys.stderr.flush()
         return
 
-    prog = HTTPOk(rpc, programs, any, url, timeout, status, inbody, email,
+    prog = HTTPOk(rpc, programs, any, url, timeout, status, nstatus, inbody, email,
                   sendmail, coredir, gcore, eager)
     prog.runforever()
 

--- a/superlance/timeoutconn.py
+++ b/superlance/timeoutconn.py
@@ -1,5 +1,6 @@
 import httplib
 import socket
+import ssl
 
 class TimeoutHTTPConnection(httplib.HTTPConnection):
     """A customised HTTPConnection allowing a per-connection
@@ -36,7 +37,6 @@ class TimeoutHTTPSConnection(httplib.HTTPSConnection):
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if self.timeout:
-            self.sock.settimeout(self.timeout)
+            sock.settimeout(self.timeout)
         sock.connect((self.host, self.port))
-        ssl = socket.ssl(sock, self.key_file, self.cert_file)
-        self.sock = httplib.FakeSocket(sock, ssl)
+        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file)


### PR DESCRIPTION
Hi,

please review  	2bf7498 for the following fixes for problems in the TimeoutHTTPSConnection class:

1.  'NoneType' object has no attribute 'settimeout'
2.  AttributeError: sendall

Additionally 416fd3c provides support for specifying multiple status codes for expected or unexpected values

Regards,
Max