### PR TITLE
delay restart

### DIFF
--- a/docs/httpok.rst
+++ b/docs/httpok.rst
@@ -117,6 +117,10 @@ Command-Line Syntax
    Disable "eager" monitoring:  do not check the URL or emit mail if no
    monitored process is in the RUNNING state.
 
+.. cmdoption:: -w <seconds>, --delay=<seconds>
+   
+   Number of seconds delay before really make a restart.
+
 .. cmdoption:: <URL>
    
    The URL to which to issue a GET request.

--- a/superlance/httpok.py
+++ b/superlance/httpok.py
@@ -26,7 +26,7 @@
 
 doc = """\
 httpok.py [-p processname] [-a] [-g] [-t timeout] [-c status_code] [-b inbody]
-          [-m mail_address] [-s sendmail] URL
+          [-m mail_address] [-s sendmail] [-w delay_seconds] URL
 
 Options:
 
@@ -81,6 +81,8 @@ Options:
 
 -E -- not "eager":  do not check URL / emit mail if no process we are
       monitoring is in the RUNNING state.
+      
+-w -- specify number of seconds delay before really make a restart.
 
 URL -- The URL to which to issue a GET request.
 
@@ -113,7 +115,8 @@ def usage():
 class HTTPOk:
     connclass = None
     def __init__(self, rpc, programs, any, url, timeout, status, inbody,
-                 email, sendmail, coredir, gcore, eager):
+                 email, sendmail, coredir, gcore, eager, delay):
+
         self.rpc = rpc
         self.programs = programs
         self.any = any
@@ -126,6 +129,7 @@ class HTTPOk:
         self.coredir = coredir
         self.gcore = gcore
         self.eager = eager
+        self.delay = delay
         self.stdin = sys.stdin
         self.stdout = sys.stdout
         self.stderr = sys.stderr
@@ -263,6 +267,10 @@ class HTTPOk:
     def restart(self, spec, write):
         namespec = make_namespec(spec['group'], spec['name'])
         if spec['state'] is ProcessStates.RUNNING:
+            if self.delay and (spec['now']-spec['start'])<self.delay:
+                write('%s is in RUNNING state %d seconds (<%d), delay restarting' % \
+                    (namespec, spec['now']-spec['start'], self.delay))
+                return
             if self.coredir and self.gcore:
                 corename = os.path.join(self.coredir, namespec)
                 m = os.popen(self.gcore + ' "%s" %s' % (corename, spec['pid']))
@@ -289,7 +297,7 @@ class HTTPOk:
 
 def main(argv=sys.argv):
     import getopt
-    short_args="hp:at:c:b:s:m:g:d:eE"
+    short_args="hp:at:c:b:s:m:g:d:eEw:"
     long_args=[
         "help",
         "program=",
@@ -303,6 +311,7 @@ def main(argv=sys.argv):
         "coredir=",
         "eager",
         "not-eager",
+        "delay=",
         ]
     arguments = argv[1:]
     try:
@@ -364,6 +373,9 @@ def main(argv=sys.argv):
         if option in ('-E', '--not-eager'):
             eager = False
 
+        if option in ('-w', '--delay'):
+            delay = value
+
     url = arguments[-1]
 
     try:
@@ -377,7 +389,7 @@ def main(argv=sys.argv):
         return
 
     prog = HTTPOk(rpc, programs, any, url, timeout, status, inbody, email,
-                  sendmail, coredir, gcore, eager)
+                  sendmail, coredir, gcore, eager, delay)
     prog.runforever()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sometimes I reported httpok annoying and unuseful restarts, especially when the process is started and the first requests respond with too long times. I propose an option to delay first restart.