### PR TITLE
Add httpctrl event listener

### DIFF
--- a/docs/httpctrl.rst
+++ b/docs/httpctrl.rst
@@ -1,0 +1,70 @@
+:command:`httpctrl` Documentation
+==================================
+
+:command:`httpctrl` is a supervisor "event listener" which may be subscribed to
+a concrete ``TICK_x`` event. When :command:`httpctrl` receives a ``TICK_x``
+event (``TICK_5`` is recommended, indicating activity every 5 seconds),
+:command:`httctrl` makes an HTTP GET request to a confgured URL. If the response 
+body contains required text :command:`httpctrl` will start child process(es).
+If the response body does not contain required text :command:`httpctrl` will
+stop child process(es).
+
+:command:`httpctrl` is incapable of monitoring the process status of processes
+which are not :command:`supervisord` child processes.
+
+:command:`httpctrl` is a "console script" installed when you install
+:mod:`superlance`.  Although :command:`httpctrl` is an executable program, it
+isn't useful as a general-purpose script:  it must be run as a
+:command:`supervisor` event listener to do anything useful.
+
+Command-Line Syntax
+-------------------
+
+.. code-block:: sh
+
+   $ httpctrl [-p processname] [-a] [-b inbody] URL
+
+.. program:: httpctrl
+
+.. cmdoption:: -p <process_name>, --program=<process_name>
+
+   Specify a supervisor 'process_name' or 'group_name'.
+
+   Starts the supervisor process if it's in STOPPED state and specified
+   string is present in body of URL.
+
+   Stops the supervisor process if it's in the RUNNING state when
+   specified string is not present in the body of URL.
+
+   If this process is part of a group, it can be specified using
+   the 'group_name:process_name' syntax.
+
+.. cmdoption:: -b <body_string>, --body=<body_string>
+
+   Specify a string which should be present in the body resulting
+   from the GET request. 
+   
+   If this string is not present in the response, the processes in 
+   the RUNNING state specified by -p will be stopped in another 
+   case it will be started.
+
+.. cmdoption:: <URL>
+   
+   The URL to which to issue a GET request.
+
+
+Configuring :command:`httpctrl` Into the Supervisor Config
+-----------------------------------------------------------
+
+An ``[eventlistener:x]`` section must be placed in :file:`supervisord.conf`
+in order for :command:`memmon` to do its work. See the "Events" chapter in the
+Supervisor manual for more information about event listeners.
+
+The following example assumes that :command:`httpctrl` is on your system
+:envvar:`PATH`.
+
+.. code-block:: ini
+
+   [eventlistener:httpctrl]
+   httpctrl.py -p program1 -p group1:program2 -p group2 http://localhost:8080/tasty
+   events=TICK_5

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,13 @@ Currently, it provides these plugins:
     request to a configured URL.  If the request fails or times out,
     :command:`httpok` will restart the "hung" child process.
 
+:command:`httpctrl`
+    This plugin is meant to be used as a supervisor event listener,
+    subscribed to ``TICK_*`` events.  :command:`httctrl` makes an HTTP GET 
+    request to a confgured URL. If the response body contains required text, 
+    :command:`httpctrl` will start child process(es). If the response body does 
+    not contain required text :command:`httpctrl` will stop child process(es).
+
 :command:`crashmail`
     This plugin is meant to be used as a supervisor event listener,
     subscribed to ``PROCESS_STATE_EXITED`` events.  It email a user when

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(name='superlance',
       entry_points = """\
       [console_scripts]
       httpok = superlance.httpok:main
+      httpctrl = superlance.httpctrl:main
       crashsms = superlance.crashsms:main
       crashmail = superlance.crashmail:main
       crashmailbatch = superlance.crashmailbatch:main

--- a/superlance/httpctrl.py
+++ b/superlance/httpctrl.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python -u
+##############################################################################
+#
+# Copyright (c) 2007 Agendaless Consulting and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the BSD-like license at
+# http://www.repoze.org/LICENSE.txt.  A copy of the license should accompany
+# this distribution.  THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL
+# EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND
+# FITNESS FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+
+##############################################################################
+# httpctrl
+# author: Jaka Hudoklin (http://github.com/offlinehacker)
+##############################################################################
+
+# A event listener meant to be subscribed to TICK_60 (or TICK_5)
+# events, which restarts processes that are children of
+# supervisord based on the response from an HTTP port.
+
+# A supervisor config snippet that tells supervisor to use this script
+# as a listener is below.
+#
+# [eventlistener:httpctrl]
+# command=python -u /bin/httpctrl http://localhost:8080/control
+# events=TICK_5
+
+doc = """\
+httpctrl.py [-p processname] [-a] [-b inbody] URL
+
+Options:
+
+-p -- specify a supervisor 'process_name' or 'group_name'. Starts
+      the supervisor process if it's in STOPPED state and specified
+      string is present in body of URL.
+      Stops the supervisor process if it's in the RUNNING state when
+      specified string is not present in the body of URL.
+      If this process is part of a group, it can be specified using
+      the 'group_name:process_name' syntax.
+
+-b -- specify a string which should be present in the body resulting
+      from the GET request. If this string is not present in the
+      response, the processes in the RUNNING state specified by -p
+      will be stopped in another case it will be started.
+
+URL -- The URL to which to issue a GET request.
+
+The -p option may be specified more than once, allowing for
+specification of multiple processes.
+
+A sample invocation:
+
+httpctrl.py -p program1 -p group1 -p group1:program2 http://localhost:8080/control
+
+"""
+
+import os
+import sys
+import urlparse
+import xmlrpclib
+
+from supervisor import childutils
+from supervisor.states import ProcessStates
+from supervisor.options import make_namespec
+
+import timeoutconn
+
+def usage():
+    print doc
+    sys.exit(255)
+
+class HTTPCtrl:
+    def __init__(self, rpc, programs, url, inbody):
+        self.rpc = rpc
+        self.programs = programs
+        self.url = url
+        self.inbody = inbody
+
+        self.timeout = 10
+
+    def listProcesses(self, state=None):
+        return [x for x in self.rpc.supervisor.getAllProcessInfo()
+                   if (x['name'] in self.programs or x['group'] in self.programs) and
+                      (state is None or x['state'] == state)]
+
+    def write_stderr(self, msg):
+        sys.stderr.write('%s\n' % msg)
+        sys.stderr.flush()
+
+    def parse_url(self):
+        parsed = urlparse.urlsplit(self.url)
+        scheme = parsed[0].lower()
+        hostport = parsed[1]
+        path = parsed[2]
+        query = parsed[3]
+
+        if query: path += '?' + query
+
+        if scheme == 'http':
+            ConnClass = timeoutconn.TimeoutHTTPConnection
+        elif scheme == 'https':
+            ConnClass = timeoutconn.TimeoutHTTPSConnection
+        else:
+            raise ValueError('Bad scheme %s' % scheme)
+
+        return (ConnClass, hostport, path)
+
+    def runforever(self):
+        ConnClass, hostport, path = self.parse_url()
+        while True:
+            headers, payload = childutils.listener.wait()
+
+            if not headers['eventname'].startswith('TICK'):
+                # do nothing with non-TICK events
+                continue
+
+            conn = ConnClass(hostport)
+            conn.timeout = self.timeout
+
+            body = ''
+            try:
+                conn.request('GET', path)
+                res = conn.getresponse()
+                body = res.read()
+            except Exception, why:
+                self.write_stderr('error contacting %s:\n %s' % (self.url, why))
+                continue
+
+            if self.inbody not in body:
+                if len(self.listProcesses(ProcessStates.RUNNING)) > 0:
+                    self.act(start = False)
+            else:
+                if len(self.listProcesses(ProcessStates.STOPPED)) > 0:
+                    self.act(start = True)
+
+            childutils.listener.ok()
+
+    def act(self, start = True):
+        try:
+            specs = self.rpc.supervisor.getAllProcessInfo()
+        except Exception, why:
+            self.write_stderr('Exception retrieving process info %s, not acting' % why)
+            return
+
+        waiting = list(self.programs)
+
+        self.write_stderr('%s selected processes %s' %
+                          ("Starting" if start else "Stopping", self.programs))
+        for spec in specs:
+            name = spec['name']
+            group = spec['group']
+            namespec = make_namespec(group, name)
+
+            if (name in self.programs or
+                group in self.programs or
+                namespec in self.programs):
+
+                self.start_stop(spec, start)
+                if name in waiting:
+                    waiting.remove(name)
+                if group in waiting:
+                    waiting.remove(group)
+                if namespec in waiting:
+                    waiting.remove(namespec)
+
+        if waiting:
+            self.write_stderr(
+                'Programs states not changed because they did not exist: %s' %
+                waiting)
+
+    def start_stop(self, spec, start=True):
+        namespec = make_namespec(spec['group'], spec['name'])
+        if spec['state'] is ProcessStates.RUNNING and not start:
+            self.write_stderr('%s is in RUNNING state, stopping' % namespec)
+            try:
+                self.rpc.supervisor.stopProcess(namespec)
+            except xmlrpclib.Fault, what:
+                self.write_stderr('Failed to stop process %s: %s' %
+                                   (namespec, what))
+            else:
+                self.write_stderr('%s stopped' % namespec)
+
+        elif spec['state'] is ProcessStates.STOPPED and start:
+            self.write_stderr('%s is in STOPPED state, starting' % namespec)
+            try:
+                self.rpc.supervisor.startProcess(namespec)
+            except xmlrpclib.Fault, what:
+                self.write_stderr('Failed to start process %s: %s' %
+                                  (namespec, what))
+            else:
+                self.write_stderr('%s started' % namespec)
+
+def main(argv=sys.argv):
+    import getopt
+    short_args="hp:b:"
+    long_args=[
+        "help",
+        "program=",
+        "body=",
+        ]
+    arguments = argv[1:]
+    try:
+        opts, args = getopt.getopt(arguments, short_args, long_args)
+    except:
+        usage()
+
+    if not args:
+        usage()
+    if len(args) > 1:
+        usage()
+
+    programs = []
+    inbody = None
+
+    for option, value in opts:
+
+        if option in ('-h', '--help'):
+            usage()
+
+        if option in ('-p', '--program'):
+            programs.append(value)
+
+        if option in ('-b', '--body'):
+            inbody = value
+
+    url = arguments[-1]
+
+    try:
+        rpc = childutils.getRPCInterface(os.environ)
+    except KeyError, why:
+        if why[0] != 'SUPERVISOR_SERVER_URL':
+            raise
+        sys.stderr.write('httpctrl must be run as a supervisor event '
+                         'listener\n')
+        sys.stderr.flush()
+        return
+
+    prog = HTTPCtrl(rpc, programs, url, inbody)
+    prog.runforever()
+
+if __name__ == '__main__':
+    main()

--- a/superlance/tests/httpctrl_test.py
+++ b/superlance/tests/httpctrl_test.py
@@ -1,0 +1,181 @@
+import unittest
+import superlance.httpctrl
+from mock import Mock, call, patch
+from supervisor.process import ProcessStates
+from superlance.tests.dummy import (DummyRPCServer,
+                                    DummySupervisorRPCNamespace,
+                                    DummyResponse)
+from superlance.httpctrl import HTTPCtrl
+
+class HTTPCtrlTests(unittest.TestCase):
+    def test_listProcesses_no_programs(self):
+        programs = []
+        ctrl = HTTPCtrl(DummyRPCServer(), programs, None, None)
+        specs = list(ctrl.listProcesses())
+        self.assertEqual(len(specs), 0)
+
+    def test_listProcesses_w_RUNNING_programs_default_state(self):
+        programs = ['foo']
+        ctrl = HTTPCtrl(DummyRPCServer(), programs, None, None)
+        specs = list(ctrl.listProcesses())
+        self.assertEqual(len(specs), 1)
+        self.assertEqual(specs[0],
+                         DummySupervisorRPCNamespace.all_process_info[0])
+
+    def test_listProcesses_w_nonRUNNING_programs_default_state(self):
+        programs = ['bar']
+        ctrl = HTTPCtrl(DummyRPCServer(), programs, None, None)
+        specs = list(ctrl.listProcesses())
+        self.assertEqual(len(specs), 1)
+        self.assertEqual(specs[0],
+                         DummySupervisorRPCNamespace.all_process_info[1])
+
+    def test_listProcesses_w_RUNNING_programs_RUNNING_state(self):
+        programs = ['foo', 'baz_01']
+        ctrl = HTTPCtrl(DummyRPCServer(), programs, None, None)
+        specs = list(ctrl.listProcesses(ProcessStates.RUNNING))
+        self.assertEqual(len(specs), 1)
+        self.assertEqual(specs[0],
+                         DummySupervisorRPCNamespace.all_process_info[0])
+
+    def test_listProcesses_w_RUNNING_programs_STOPPED_state(self):
+        programs = ['baz_01', 'foo']
+        ctrl = HTTPCtrl(DummyRPCServer(), programs, None, None)
+        specs = list(ctrl.listProcesses(ProcessStates.STOPPED))
+        self.assertEqual(len(specs), 1)
+        self.assertEqual(specs[0],
+                         DummySupervisorRPCNamespace.all_process_info[2])
+
+    def test_listProcesses_w_RUNNING_groups_STOPPED_state(self):
+        programs = ['baz']
+        ctrl = HTTPCtrl(DummyRPCServer(), programs, None, None)
+        specs = list(ctrl.listProcesses(ProcessStates.STOPPED))
+        self.assertEqual(len(specs), 1)
+        self.assertEqual(specs[0],
+                         DummySupervisorRPCNamespace.all_process_info[2])
+
+    def test_parse_url(self):
+        url = "http://foo:8080/bar?baz"
+        ctrl = HTTPCtrl(DummyRPCServer(), [], url, None)
+        (ConnClass, hostport, path) = ctrl.parse_url()
+
+        self.assertEqual(ConnClass,
+                         superlance.httpctrl.timeoutconn.TimeoutHTTPConnection,
+                         msg = "Class not TimeoutHTTPConnection")
+        self.assertEqual(hostport, "foo:8080", msg = "HTTP host incorrect")
+        self.assertEqual(path, "/bar?baz", msg = "HTTP path incorrect")
+
+        url = "https://foo:8080/"
+        ctrl = HTTPCtrl(DummyRPCServer(), [], url, None)
+        (ConnClass, hostport, path) = ctrl.parse_url()
+
+        self.assertEqual(ConnClass,
+                         superlance.httpctrl.timeoutconn.TimeoutHTTPSConnection,
+                         msg = "Class not TimeoutHTTPSConnection")
+
+    def test_runforever_notatick_atick(self):
+        # Preparing mocks
+        url = "http://foo/bar/baz"
+        ctrl = HTTPCtrl(DummyRPCServer(), [], url, None)
+        ctrl.parse_url = Mock(
+            return_value = (Mock(side_effect=Exception("dummy exception")), None, None)
+        )
+
+        config = {'wait.side_effect': [
+            ({'eventname': 'NOTATICK', 'len': 0}, None),
+            ({'eventname': 'TICK', 'len': 0}, None)
+        ]}
+        childutils_listener_patch = patch("superlance.httpctrl.childutils.listener",
+                                          **config)
+        mock_wait = childutils_listener_patch.start()
+
+        # Testing
+        self.assertRaisesRegexp(Exception, "dummy exception", ctrl.runforever)
+        self.assertEqual(mock_wait.mock_calls, [call.wait(), call.wait()])
+        ctrl.parse_url.assert_called_with()
+
+        childutils_listener_patch.stop()
+
+    def test_runforever_inbody(self):
+        # Preparing mocks
+        url = "http://foo/bar?baz"
+        ctrl = HTTPCtrl(DummyRPCServer(), ["baz_01"], url, "OK")
+
+        config = {'wait.side_effect': [({'eventname': 'TICK', 'len': 0}, None)],
+                  'ok.side_effect': [Exception("dummy exception")]
+                 }
+        childutils_listener_patch = patch("superlance.httpctrl.childutils.listener",
+                                          **config)
+        mock_wait = childutils_listener_patch.start()
+
+        conn_mock = Mock()
+        conn_class_mock = Mock(return_value = conn_mock)
+        conn_mock.getresponse = Mock(return_value = DummyResponse())
+        ctrl.parse_url = Mock(
+            return_value = (conn_class_mock, "foo", "/bar")
+        )
+
+        ctrl.act = Mock()
+
+        # Testing
+        self.assertRaisesRegexp(Exception, "dummy exception", ctrl.runforever)
+        self.assertEqual(mock_wait.mock_calls, [call.wait(), call.ok()])
+        conn_mock.request.assert_called_once_with('GET', '/bar')
+        ctrl.act.assert_called_once_with(start=True)
+
+        childutils_listener_patch.stop()
+
+    def test_act_start(self):
+        # Preparing mocks
+        ctrl = HTTPCtrl(DummyRPCServer(), ["baz", "maz"], None, None)
+        ctrl.start_stop = Mock()
+        ctrl.write_stderr = Mock()
+
+        # Testing
+        ctrl.act(start = True)
+        ctrl.start_stop.assert_called_once_with(
+            DummySupervisorRPCNamespace.all_process_info[2], True
+        )
+        ctrl.write_stderr.assert_called_with(
+            "Programs states not changed because they did not exist: ['maz']"
+        )
+
+    def test_act_stop(self):
+        # Preparing mocks
+        ctrl = HTTPCtrl(DummyRPCServer(), ["foo", "maz"], None, None)
+        ctrl.start_stop = Mock()
+        ctrl.write_stderr = Mock()
+
+        # Testing
+        ctrl.act(start = False)
+        ctrl.start_stop.assert_called_once_with(
+            DummySupervisorRPCNamespace.all_process_info[0], False
+        )
+        ctrl.write_stderr.assert_called_with(
+            "Programs states not changed because they did not exist: ['maz']"
+        )
+
+    def test_start_stop_stop(self):
+        # Preparing mocks
+        ctrl = HTTPCtrl(DummyRPCServer(), ["foo"], None, None)
+        ctrl.rpc.supervisor.stopProcess = Mock()
+        ctrl.write_stderr = Mock()
+
+        # Testing
+        ctrl.start_stop(DummySupervisorRPCNamespace.all_process_info[0],
+                        start = False)
+        ctrl.rpc.supervisor.stopProcess.assert_called_once_with("foo")
+
+    def test_start_stop_start(self):
+        # Preparing mocks
+        ctrl = HTTPCtrl(DummyRPCServer(), ["baz_01"], None, None)
+        ctrl.rpc.supervisor.startProcess = Mock()
+        ctrl.write_stderr = Mock()
+
+        # Testing
+        ctrl.start_stop(DummySupervisorRPCNamespace.all_process_info[2],
+                        start = True)
+        ctrl.rpc.supervisor.startProcess.assert_called_once_with("baz:baz_01")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
*This event listener controls processes based on the response of HTTP server(GET request). It does stop them or start them based on if some string is contained in response body or not.*

**This is my use scenario:**
I have a video stream, which is controlled(started and stopped)  using supervisor. To connect it with web interface, I created this event listener, which allows me to control it automatically and on very sane way, thanks to supervisor and superlance :)

- I think this feature is basic and really useful, so I think it should be included in superlance.

Code, tests and docs included!