### PR TITLE
Allow SMTP credentials to be supplied to ProcessStateEmailMonitor

### DIFF
--- a/superlance/fatalmailbatch.py
+++ b/superlance/fatalmailbatch.py
@@ -29,6 +29,9 @@ fatalmailbatch.py [--interval=<batch interval in minutes>]
         [--toEmail=<email address>]
         [--fromEmail=<email address>]
         [--subject=<email subject>]
+        [--smtpHost=<smtp server>]
+        [--userName=<smtp server username>]
+        [--password=<smtp server password]
 
 Options:
 

--- a/superlance/process_state_email_monitor.py
+++ b/superlance/process_state_email_monitor.py
@@ -46,7 +46,10 @@ class ProcessStateEmailMonitor(ProcessStateMonitor):
                           help="SMTP server hostname or address")
         parser.add_option("-e", "--tickEvent", dest="eventname", default="TICK_60",
                           help="TICK event name (defaults to TICK_60)")
-        
+        parser.add_option("-u", "--userName", dest="smtp_user", default="",
+                          help="SMTP server user name (defaults to nothing)")
+        parser.add_option("-p", "--password", dest="smtp_password", default="",
+                          help="SMTP server password (defaults to nothing)")
         (options, args) = parser.parse_args()
         return options
         
@@ -84,6 +87,8 @@ class ProcessStateEmailMonitor(ProcessStateMonitor):
         self.to_emails = kwargs['to_emails']
         self.subject = kwargs.get('subject')
         self.smtp_host = kwargs.get('smtp_host', 'localhost')
+        self.smtp_user = kwargs.get('smtp_user')
+        self.smtp_password = kwargs.get('smtp_password')
         self.digest_len = 76
 
     def send_batch_notification(self):
@@ -125,6 +130,8 @@ From: %(from)s\nSubject: %(subject)s\nBody:\n%(body)s\n" % email_for_log)
     def send_smtp(self, mime_msg, to_emails):
         s = smtplib.SMTP(self.smtp_host)
         try:
+            if self.smtp_user and self.smtp_password:
+                s.login(self.smtp_user,self.smtp_password)
             s.sendmail(mime_msg['From'], to_emails, mime_msg.as_string())
         except:
             s.quit()


### PR DESCRIPTION
I added some functionality to login to the SMTP server, specifically so I could send emails from Webfaction. 

If this is of use to anyone else I can add the required documentation to the other utilities that use ProcessStateEmailMonitor, make any other alterations as required, and then update the Pull Request.

Best wishes,
Steven.    
