### PR TITLE
fix argument parsing (uptime and name got mixed up) and add a test

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -9,6 +9,8 @@ Contributors
 
 - Joaquín Cuenca Abela, 2011-06-23
 
+- Harald Friessnegger, 2012-11-01
+
 - Mikhail Lukyanchenko, 2013-12-23
 
 - Patrick Gerken, 2014-01-27

--- a/superlance/memmon.py
+++ b/superlance/memmon.py
@@ -79,6 +79,7 @@ memmon.py -p program1=200MB -p theprog:thegroup=100MB -g thegroup=100MB -a 1GB -
 import os
 import sys
 import time
+from superlance.compat import maxint
 from superlance.compat import xmlrpclib
 
 from supervisor import childutils
@@ -93,7 +94,7 @@ def shell(cmd):
         return f.read()
 
 class Memmon:
-    def __init__(self, programs, groups, any, sendmail, email, email_uptime_limit, name, rpc):
+    def __init__(self, programs, groups, any, sendmail, email, email_uptime_limit, name, rpc=None):
         self.programs = programs
         self.groups = groups
         self.any = any
@@ -126,14 +127,14 @@ class Memmon:
                 keys = sorted(self.programs.keys())
                 status.append(
                     'Checking programs %s' % ', '.join(
-                    [ '%s=%s' % (k, self.programs[k]) for k in keys ] )
+                    [ '%s=%s' % (k, self.programs[k]) for k in keys ])
                     )
 
             if self.groups:
                 keys = sorted(self.groups.keys())
                 status.append(
                     'Checking groups %s' % ', '.join(
-                    [ '%s=%s' % (k, self.groups[k]) for k in keys ] )
+                    [ '%s=%s' % (k, self.groups[k]) for k in keys ])
                     )
             if self.any is not None:
                 status.append('Checking any=%s' % self.any)
@@ -197,7 +198,7 @@ class Memmon:
         try:
             self.rpc.supervisor.stopProcess(name)
         except xmlrpclib.Fault as e:
-            msg = ('Failed to stop process %s (RSS %s), exiting: %s' %
+            msg = ('Failed to stop process %s (RSS %s), exiting: %s' % 
                    (name, rss, e))
             self.stderr.write(str(msg))
             if self.email:
@@ -227,7 +228,7 @@ class Memmon:
             self.mail(self.email, subject, msg)
 
     def mail(self, email, subject, msg):
-        body =  'To: %s\n' % self.email
+        body = 'To: %s\n' % self.email
         body += 'Subject: %s\n' % subject
         body += '\n'
         body += msg
@@ -255,8 +256,8 @@ def parse_size(option, value):
 
 seconds_size = SuffixMultiplier({'s': 1,
                                  'm': 60,
-                                 'h': 60*60,
-                                 'd': 60*60*24
+                                 'h': 60 * 60,
+                                 'd': 60 * 60 * 24
                                  })
 
 def parse_seconds(option, value):
@@ -267,10 +268,10 @@ def parse_seconds(option, value):
         usage()
     return seconds
 
-def main():
+def memmon_from_args(arguments):
     import getopt
-    short_args="hp:g:a:s:m:n:u:"
-    long_args=[
+    short_args = "hp:g:a:s:m:n:u:"
+    long_args = [
         "help",
         "program=",
         "group=",
@@ -280,27 +281,26 @@ def main():
         "uptime=",
         "name=",
         ]
-    arguments = sys.argv[1:]
+
     if not arguments:
-        usage()
+        return None
     try:
-        opts, args=getopt.getopt(arguments, short_args, long_args)
+        opts, args = getopt.getopt(arguments, short_args, long_args)
     except:
-        print(__doc__)
-        sys.exit(2)
+        return None
 
     programs = {}
     groups = {}
     any = None
     sendmail = '/usr/sbin/sendmail -t -i'
     email = None
-    uptime = sys.maxint
+    uptime_limit = maxint
     name = None
 
     for option, value in opts:
 
         if option in ('-h', '--help'):
-            usage()
+            return None
 
         if option in ('-p', '--program'):
             name, size = parse_namesize(option, value)
@@ -321,13 +321,26 @@ def main():
             email = value
 
         if option in ('-u', '--uptime'):
-            uptime = parse_seconds(option, value)
+            uptime_limit = parse_seconds(option, value)
 
         if option in ('-n', '--name'):
             name = value
 
-    rpc = childutils.getRPCInterface(os.environ)
-    memmon = Memmon(programs, groups, any, sendmail, email, name, uptime, rpc)
+    memmon = Memmon(programs=programs,
+                    groups=groups,
+                    any=any,
+                    sendmail=sendmail,
+                    email=email,
+                    email_uptime_limit=uptime_limit,
+                    name=name)
+    return memmon
+
+def main():
+    memmon = memmon_from_args(sys.argv[1:])
+    if memmon is None:
+        # something went wrong or -h has been given
+        usage()
+    memmon.rpc = childutils.getRPCInterface(os.environ)
     memmon.runforever()
 
 if __name__ == '__main__':


### PR DESCRIPTION
in commit https://github.com/Supervisor/superlance/commit/8603ce441c04a1b91b2e009e154bdccf552f3573 i mixed up the order of parameters in the init function resulting in the name being set to the uptime in seconds and the other way round.
factored out argument parsing into a separate method and added a test for it. hope this ensures mistakes like this one will be catched earlier next time ;-)
