### PR TITLE
Memmon: Add support for checking against cumulative RSS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 1.0.0-dev (Next Release)
 ------------------------
 
+- Added support for ``memmon`` to check against cumulative RSS of a process
+  and all its child processes.
+  Patch by Lukas Graf
+
 - Dropped support for Python 2.5.
 
 - Added support for Python 3.2 and 3.3.

--- a/docs/memmon.rst
+++ b/docs/memmon.rst
@@ -16,7 +16,9 @@ tested on other operating systems (it relies on :command:`ps` output and
 command-line switches).
 
 :command:`memmon` is incapable of monitoring the process status of processes
-which are not :command:`supervisord` child processes.
+which are not :command:`supervisord` child processes. Without the
+`--cumulative` option, only the RSS of immediate children of the
+:command:`supervisord` process will be considered.
 
 :command:`memmon` is a "console script" installed when you install
 :mod:`superlance`.  Although :command:`memmon` is an executable program, it
@@ -28,7 +30,7 @@ Command-Line Syntax
 
 .. code-block:: sh
 
-   $ memmon [-p processname=byte_size] [-g groupname=byte_size] \
+   $ memmon [-c] [-p processname=byte_size] [-g groupname=byte_size] \
             [-a byte_size] [-s sendmail] [-m email_address] \
             [-u email_uptime_limit] [-n memmon_name]
 
@@ -37,6 +39,12 @@ Command-Line Syntax
 .. cmdoption:: -h, --help
 
    Show program help.
+
+.. cmdoption:: -c, --cumulative
+
+   Check against cumulative RSS. When calculating a process' RSS, also
+   consider its child processes. With this option `memmon` will sum up
+   the RSS of the process to be monitored and all its children.
 
 .. cmdoption:: -p <name/size pair>, --program=<name/size pair>
 

--- a/superlance/memmon.py
+++ b/superlance/memmon.py
@@ -27,11 +27,15 @@
 # events=TICK_60
 
 doc = """\
-memmon.py [-p processname=byte_size]  [-g groupname=byte_size]
+memmon.py [-c] [-p processname=byte_size] [-g groupname=byte_size]
           [-a byte_size] [-s sendmail] [-m email_address]
-          [-u uptime][-n memmon_name]
+          [-u uptime] [-n memmon_name]
 
 Options:
+
+-c -- Check against cumulative RSS. When calculating a process' RSS, also
+      consider its child processes. With this option `memmon` will sum up
+      the RSS of the process to be monitored and all its children.
 
 -p -- specify a process_name=byte_size pair.  Restart the supervisor
       process named 'process_name' when it uses more than byte_size
@@ -79,6 +83,7 @@ memmon.py -p program1=200MB -p theprog:thegroup=100MB -g thegroup=100MB -a 1GB -
 import os
 import sys
 import time
+from collections import namedtuple
 from superlance.compat import maxint
 from superlance.compat import xmlrpclib
 
@@ -94,7 +99,8 @@ def shell(cmd):
         return f.read()
 
 class Memmon:
-    def __init__(self, programs, groups, any, sendmail, email, email_uptime_limit, name, rpc=None):
+    def __init__(self, cumulative, programs, groups, any, sendmail, email, email_uptime_limit, name, rpc=None):
+        self.cumulative = cumulative
         self.programs = programs
         self.groups = groups
         self.any = any
@@ -107,6 +113,7 @@ class Memmon:
         self.stdout = sys.stdout
         self.stderr = sys.stderr
         self.pscommand = 'ps -orss= -p %s'
+        self.pstreecommand = 'ps ax -o "pid= ppid= rss="'
         self.mailed = False # for unit tests
 
     def runforever(self, test=False):
@@ -222,18 +229,57 @@ class Memmon:
             self.mail(self.email, subject, msg)
 
     def calc_rss(self, pid):
-        data = shell(self.pscommand % pid)
-        if not data:
-            # no such pid (deal with race conditions)
-            return None
 
-        try:
-            rss = data.lstrip().rstrip()
-            rss = int(rss) * 1024 # rss is in KB
-        except ValueError:
-            # line doesn't contain any data, or rss cant be intified
-            return None
+        ProcInfo = namedtuple('ProcInfo', ['pid', 'ppid', 'rss'])
 
+        def find_children(parent_pid, procs):
+            children = []
+            for proc in procs:
+                pid, ppid, rss = proc
+                if ppid == parent_pid:
+                    children.append(proc)
+                    children.extend(find_children(pid, procs))
+            return children
+
+        def cum_rss(pid, procs):
+            parent_proc = [p for p in procs if p.pid == pid][0]
+            children = find_children(pid, procs)
+            tree = [parent_proc] + children
+            total_rss = sum(map(int, [p.rss for p in tree]))
+            return total_rss
+
+        def get_all_process_infos(data):
+            data = data.strip()
+            procs = []
+            for line in data.splitlines():
+                pid, ppid, rss = map(int, line.split())
+                procs.append(ProcInfo(pid=pid, ppid=ppid, rss=rss))
+            return procs
+
+        if self.cumulative:
+            data = shell(self.pstreecommand)
+            procs = get_all_process_infos(data)
+
+            try:
+                rss = cum_rss(pid, procs)
+            except (ValueError, IndexError):
+                # Could not determine cumulative RSS
+                return None
+
+        else:
+            data = shell(self.pscommand % pid)
+            if not data:
+                # no such pid (deal with race conditions)
+                return None
+
+            try:
+                rss = data.lstrip().rstrip()
+                rss = int(rss)
+            except ValueError:
+                # line doesn't contain any data, or rss cant be intified
+                return None
+
+        rss = rss * 1024  # rss is in KB
         return rss
 
     def mail(self, email, subject, msg):
@@ -279,9 +325,10 @@ def parse_seconds(option, value):
 
 def memmon_from_args(arguments):
     import getopt
-    short_args = "hp:g:a:s:m:n:u:"
+    short_args = "hcp:g:a:s:m:n:u:"
     long_args = [
         "help",
+        "cumulative",
         "program=",
         "group=",
         "any=",
@@ -298,6 +345,7 @@ def memmon_from_args(arguments):
     except:
         return None
 
+    cumulative = False
     programs = {}
     groups = {}
     any = None
@@ -310,6 +358,9 @@ def memmon_from_args(arguments):
 
         if option in ('-h', '--help'):
             return None
+
+        if option in ('-c', '--cumulative'):
+            cumulative = True
 
         if option in ('-p', '--program'):
             name, size = parse_namesize(option, value)
@@ -335,7 +386,8 @@ def memmon_from_args(arguments):
         if option in ('-n', '--name'):
             name = value
 
-    memmon = Memmon(programs=programs,
+    memmon = Memmon(cumulative=cumulative,
+                    programs=programs,
                     groups=groups,
                     any=any,
                     sendmail=sendmail,

--- a/superlance/tests/memmon_test.py
+++ b/superlance/tests/memmon_test.py
@@ -15,11 +15,12 @@ class MemmonTests(unittest.TestCase):
 
     def _makeOnePopulated(self, programs, groups, any):
         rpc = DummyRPCServer()
+        cumulative = False
         sendmail = 'cat - > /dev/null'
         email = 'chrism@plope.com'
         name = 'test'
         uptime_limit = 2000
-        memmon = self._makeOne(programs, groups, any, sendmail, email, uptime_limit, name, rpc)
+        memmon = self._makeOne(cumulative, programs, groups, any, sendmail, email, uptime_limit, name, rpc)
         memmon.stdin = StringIO()
         memmon.stdout = StringIO()
         memmon.stderr = StringIO()
@@ -263,6 +264,61 @@ class MemmonTests(unittest.TestCase):
         memmon.runforever(test=True)
         self.assertFalse(memmon.mailed, 'no email should be sent because uptime is above limit')
 
+    def test_calc_rss_not_cumulative(self):
+        programs = {}
+        groups = {}
+        any = None
+        memmon = self._makeOnePopulated(programs, groups, any)
+
+        noop = '_=%s; '
+        pid = 1
+
+        memmon.pscommand = noop + 'echo 16'
+        rss = memmon.calc_rss(pid)
+        self.assertEquals(16 * 1024, rss)
+
+        memmon.pscommand = noop + 'echo not_an_int'
+        rss = memmon.calc_rss(pid)
+        self.assertEquals(
+            None, rss, 'Failure to parse an integer RSS value from the ps '
+            'output should result in calc_rss() returning None.')
+
+    def test_calc_rss_cumulative(self):
+        """Let calc_rss() do its work on a fake process tree:
+
+        |-+= 99
+        | \-+= 1
+        |   \-+- 2
+        |     |-+- 3
+        |     \-+- 4
+
+        (Where the process with PID 1 is the one being monitored)
+        """
+        programs = {}
+        groups = {}
+        any = None
+        memmon = self._makeOnePopulated(programs, groups, any)
+        memmon.cumulative = True
+
+        # output of ps ax -o "pid= ppid= rss=" representing the process
+        # tree described above, including extraneous whitespace and
+        # unrelated processes.
+        ps_output = """
+        11111 22222    333
+        1     99       100
+        2     1        200
+        3     2        300
+        4     2        400
+        11111 22222    333
+        """
+
+        memmon.pstreecommand = 'echo "%s"' % ps_output
+        rss = memmon.calc_rss(1)
+        self.assertEquals(
+            1000 * 1024, rss,
+            'Cumulative RSS of the test process and its three children '
+            'should add up to 1000 kb.')
+
     def test_argparser(self):
         """test if arguments are parsed correctly
         """
@@ -273,7 +329,8 @@ class MemmonTests(unittest.TestCase):
 
 
         #all arguments
-        arguments = ['-p', 'foo=50MB',
+        arguments = ['-c',
+                     '-p', 'foo=50MB',
                      '-g', 'bar=10kB',
                      '--any', '250',
                      '-s', 'mutt',
@@ -281,6 +338,7 @@ class MemmonTests(unittest.TestCase):
                      '-u', '1d',
                      '-n', 'myproject']
         memmon = memmon_from_args(arguments)
+        self.assertEqual(memmon.cumulative, True)
         self.assertEqual(memmon.programs['foo'], 50 * 1024 * 1024)
         self.assertEqual(memmon.groups['bar'], 10 * 1024)
         self.assertEqual(memmon.any, 250)
@@ -293,6 +351,7 @@ class MemmonTests(unittest.TestCase):
         #default arguments
         arguments = ['-m', 'me@you.com']
         memmon = memmon_from_args(arguments)
+        self.assertEqual(memmon.cumulative, False)
         self.assertEqual(memmon.programs, {})
         self.assertEqual(memmon.groups, {})
         self.assertEqual(memmon.any, None)


### PR DESCRIPTION
This change fixes the issue brought up in https://github.com/Supervisor/superlance/issues/21 and addresses the points made by @mnaberez  in pull request https://github.com/Supervisor/superlance/pull/22:
- Works with plain `ps` instead of `pstree`
- Unit tests included
- Argument parser / usage, docs and changelog have been updated

The implementation works by using `ps` to list PID, PPID (Parent PID) and RSS, then recursively gathering all child processes of the one being monitored, and summing up all their RSS values.

When implementing this, I took care not to modify the default behavior at all, and touched the existing code as little as possible (basically just factored out RSS calculation into a separate [`calc_rss(pid)`](https://github.com/lukasgraf/superlance/blob/199b69f5d2a0f1e257c2b2a2263ca28d5b54614c/superlance/memmon.py#L224) method and then extended it with the behavior required for calculating cumulative RSS).

I tested the specific `ps` options I'm using (`ps ax -o "pid= ppid= rss="`) on Linux (CentOS and SuSE) and OS X 10.9.4.

/cc @rgarcia @CMCDragonkai @kvdb
