### PR TITLE
Support HTTP Basic Authentication for httpok checks

### DIFF
--- a/superlance/timeoutconn.py
+++ b/superlance/timeoutconn.py
@@ -1,5 +1,6 @@
 from superlance.compat import httplib
 import socket
+import ssl
 
 class TimeoutHTTPConnection(httplib.HTTPConnection):
     """A customised HTTPConnection allowing a per-connection
@@ -36,7 +37,6 @@ class TimeoutHTTPSConnection(httplib.HTTPSConnection):
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if self.timeout:
-            self.sock.settimeout(self.timeout)
+            sock.settimeout(self.timeout)
         sock.connect((self.host, self.port))
-        ssl = socket.ssl(sock, self.key_file, self.cert_file)
-        self.sock = httplib.FakeSocket(sock, ssl)
+        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file)


### PR DESCRIPTION
We are checking an endpoint that we have basic authentication on with `httpok` and figured this might be useful for others as well:
- Accept a `username:password` string for basic authentication
- Fix settimeout for https (was raising NoneType has no attribute settimeout)
  (Same fix as https://github.com/maxnaude/superlance/commit/2bf7498603ee351c6f6baa6a45e4ccd554802030)
- Move headers creation outside of retry loop since the headers stay the same

Let me know if there are any tests that should be written for this.
