### PR TITLE
Create -P and -G options for program and group exceptions

### DIFF
--- a/superlance/memmon.py
+++ b/superlance/memmon.py
@@ -347,12 +347,14 @@ def parse_seconds(option, value):
 
 def memmon_from_args(arguments):
     import getopt
-    short_args = "hcp:g:a:s:m:n:u:"
+    short_args = "hcp:g:a:s:m:n:u:P:G:"
     long_args = [
         "help",
         "cumulative",
         "program=",
+        "program-exception=",
         "group=",
+        "group-exception=",
         "any=",
         "sendmail_program=",
         "email=",

--- a/superlance/memmon.py
+++ b/superlance/memmon.py
@@ -192,12 +192,7 @@ class Memmon:
 
                 for n in name, pname:
                     if n in self.program_exceptions:
-                        self.stderr.write('RSS of %s is %s\n' % (pname, rss))
-                        if  rss > self.program_exceptions[n]:
-                            self.restart(pname, rss)
-                            continue
-                        else:
-                            continue
+                        continue
 
                 if group in self.groups:
                     self.stderr.write('RSS of %s is %s\n' % (pname, rss))
@@ -206,12 +201,7 @@ class Memmon:
                         continue
 
                 if group in self.group_exceptions:
-                    self.stderr.write('RSS of %s is %s\n' % (pname, rss))
-                    if rss > self.group_exceptions[group]:
-                        self.restart(pname, rss)
-                        continue
-                    else:
-                        continue
+                    continue
 
                 if self.any is not None:
                     self.stderr.write('RSS of %s is %s\n' % (pname, rss))
@@ -380,9 +370,9 @@ def memmon_from_args(arguments):
 
     cumulative = False
     programs = {}
-    program_exceptions = {}
+    program_exceptions = []
     groups = {}
-    group_exceptions = {}
+    group_exceptions = []
     any = None
     sendmail = '/usr/sbin/sendmail -t -i'
     email = None
@@ -407,11 +397,13 @@ def memmon_from_args(arguments):
 
         if option in ('-P', '--program-exception'):
             name, size = parse_namesize(option, value)
-            program_exceptions[name] = size
+            programs[name] = size
+            group_exceptions.append(name)
 
         if option in ('-G', '--group-exception'):
             name, size = parse_namesize(option, value)
-            group_exceptions[name] = size
+            groups[name] = size
+            program_exceptions.append(name)
 
         if option in ('-a', '--any'):
             size = parse_size(option, value)

--- a/superlance/memmon.py
+++ b/superlance/memmon.py
@@ -68,6 +68,11 @@ Options:
       be used in the email subject to identify which memmon process
       restarted the process.
 
+-o -- override. By default, if you specify -a 100MB then you can only
+      use -g and -p to set a LOWER limit. You can't use -g and -p to
+      set a higher limit. If -o is set, -g and -p set higher limits
+      not lower limits than -a
+
 The -p and -g options may be specified more than once, allowing for
 specification of multiple groups and processes.
 
@@ -99,7 +104,7 @@ def shell(cmd):
         return f.read()
 
 class Memmon:
-    def __init__(self, cumulative, programs, groups, any, sendmail, email, email_uptime_limit, name, rpc=None):
+    def __init__(self, cumulative, programs, groups, any, sendmail, email, email_uptime_limit, name, rpc=None, override=False):
         self.cumulative = cumulative
         self.programs = programs
         self.groups = groups
@@ -115,6 +120,7 @@ class Memmon:
         self.pscommand = 'ps -orss= -p %s'
         self.pstreecommand = 'ps ax -o "pid= ppid= rss="'
         self.mailed = False # for unit tests
+        self.override = override
 
     def runforever(self, test=False):
         while 1:
@@ -173,12 +179,18 @@ class Memmon:
                         if  rss > self.programs[name]:
                             self.restart(pname, rss)
                             continue
+                        else:
+                            if self.override:
+                                continue
 
                 if group in self.groups:
                     self.stderr.write('RSS of %s is %s\n' % (pname, rss))
                     if rss > self.groups[group]:
                         self.restart(pname, rss)
                         continue
+                    else:
+                        if self.override:
+                            continue
 
                 if self.any is not None:
                     self.stderr.write('RSS of %s is %s\n' % (pname, rss))
@@ -346,6 +358,7 @@ def memmon_from_args(arguments):
         return None
 
     cumulative = False
+    override = False
     programs = {}
     groups = {}
     any = None
@@ -361,6 +374,9 @@ def memmon_from_args(arguments):
 
         if option in ('-c', '--cumulative'):
             cumulative = True
+
+        if option in ('-c', '--override'):
+            override = True
 
         if option in ('-p', '--program'):
             name, size = parse_namesize(option, value)
@@ -393,7 +409,8 @@ def memmon_from_args(arguments):
                     sendmail=sendmail,
                     email=email,
                     email_uptime_limit=uptime_limit,
-                    name=name)
+                    name=name,
+                    override=override)
     return memmon
 
 def main():

--- a/superlance/memmon.py
+++ b/superlance/memmon.py
@@ -190,9 +190,8 @@ class Memmon:
                             self.restart(pname, rss)
                             continue
 
-                for n in name, pname:
-                    if n in self.program_exceptions:
-                        continue
+                if name in self.program_exceptions or pname in self.program_exceptions:
+                    continue
 
                 if group in self.groups:
                     self.stderr.write('RSS of %s is %s\n' % (pname, rss))

--- a/superlance/memmon.py
+++ b/superlance/memmon.py
@@ -112,8 +112,9 @@ def shell(cmd):
         return f.read()
 
 class Memmon:
-    def __init__(self, cumulative, programs, groups, any, sendmail, email, email_uptime_limit, name, program_exceptions,
-                 group_exceptions, rpc=None):
+    def __init__(self, cumulative, programs, groups, any, sendmail, email, email_uptime_limit, name, rpc=None,
+                 program_exceptions=[],
+                 group_exceptions=[]):
         self.cumulative = cumulative
         self.programs = programs
         self.groups = groups

--- a/superlance/memmon.py
+++ b/superlance/memmon.py
@@ -186,14 +186,14 @@ class Memmon:
                 for n in name, pname:
                     if n in self.programs:
                         self.stderr.write('RSS of %s is %s\n' % (pname, rss))
-                        if  rss > self.programs[name]:
+                        if  rss > self.programs[n]:
                             self.restart(pname, rss)
                             continue
 
                 for n in name, pname:
                     if n in self.program_exceptions:
                         self.stderr.write('RSS of %s is %s\n' % (pname, rss))
-                        if  rss > self.program_exceptions[name]:
+                        if  rss > self.program_exceptions[n]:
                             self.restart(pname, rss)
                             continue
                         else:


### PR DESCRIPTION
Currently, the behavior if you have -a and a -p or a -g, or a -g for a group which contains a process that has a -p associated with it, the "higher level" limit is binding if the "lower level" limit is higher. I.e. You can use -p to set a limit that is LOWER than the -a limit, but you can't use -p to set a limit that is higher than the -a limit. New options, -P and -G, allow you to set a limit that is higher than the one set at the higher level in the hierarchy.
