### PR TITLE
prepend hostname in email subject

### DIFF
--- a/superlance/httpok.py
+++ b/superlance/httpok.py
@@ -261,7 +261,7 @@ class HTTPOk:
 
     def mail(self, email, subject, msg):
         body =  'To: %s\n' % self.email
-        body += 'Subject: %s\n' % subject
+        body += 'Subject: [%s] %s\n' % (socket.gethostname(), subject)
         body += '\n'
         body += msg
         with os.popen(self.sendmail, 'w') as m:

--- a/superlance/tests/httpok_test.py
+++ b/superlance/tests/httpok_test.py
@@ -150,7 +150,7 @@ class HTTPOkTests(unittest.TestCase):
         self.assertEqual(len(mailed), 12)
         self.assertEqual(mailed[0], 'To: chrism@plope.com')
         self.assertEqual(mailed[1],
-                    'Subject: httpok for http://foo/bar: bad status returned')
+                    'Subject: [%s] httpok for http://foo/bar: bad status returned' % socket.gethostname())
 
     def test_runforever_eager_error_on_request_any(self):
         programs = []
@@ -171,7 +171,8 @@ class HTTPOkTests(unittest.TestCase):
         self.assertEqual(len(mailed), 11)
         self.assertEqual(mailed[0], 'To: chrism@plope.com')
         self.assertEqual(mailed[1],
-                    'Subject: httpok for http://foo/bar: bad status returned')
+                    'Subject: [%s] httpok for http://foo/bar: bad status returned' % socket.gethostname())
+
 
     def test_runforever_eager_error_on_process_stop(self):
         programs = ['FAILED']
@@ -192,7 +193,7 @@ class HTTPOkTests(unittest.TestCase):
         self.assertEqual(len(mailed), 10)
         self.assertEqual(mailed[0], 'To: chrism@plope.com')
         self.assertEqual(mailed[1],
-                    'Subject: httpok for http://foo/bar: bad status returned')
+                    'Subject: [%s] httpok for http://foo/bar: bad status returned' % socket.gethostname())
 
     def test_runforever_eager_error_on_process_start(self):
         programs = ['SPAWN_ERROR']
@@ -214,7 +215,7 @@ class HTTPOkTests(unittest.TestCase):
         self.assertEqual(len(mailed), 9)
         self.assertEqual(mailed[0], 'To: chrism@plope.com')
         self.assertEqual(mailed[1],
-                    'Subject: httpok for http://foo/bar: bad status returned')
+                    'Subject: [%s] httpok for http://foo/bar: bad status returned' % socket.gethostname())
 
     def test_runforever_eager_gcore(self):
         programs = ['foo', 'bar', 'baz_01', 'notexisting']
@@ -243,7 +244,7 @@ class HTTPOkTests(unittest.TestCase):
         self.assertEqual(len(mailed), 15)
         self.assertEqual(mailed[0], 'To: chrism@plope.com')
         self.assertEqual(mailed[1],
-                    'Subject: httpok for http://foo/bar: bad status returned')
+                    'Subject: [%s] httpok for http://foo/bar: bad status returned' % socket.gethostname())
 
     def test_runforever_not_eager_none_running(self):
         programs = ['bar', 'baz_01']
@@ -275,7 +276,7 @@ class HTTPOkTests(unittest.TestCase):
         self.assertEqual(len(mailed), 10)
         self.assertEqual(mailed[0], 'To: chrism@plope.com')
         self.assertEqual(mailed[1],
-                    'Subject: httpok for http://foo/bar: bad status returned')
+                    'Subject: [%s] httpok for http://foo/bar: bad status returned' % socket.gethostname())
 
     def test_runforever_honor_timeout_on_connrefused(self):
         programs = ['foo', 'bar']
@@ -310,7 +311,7 @@ class HTTPOkTests(unittest.TestCase):
         self.assertEqual(len(mailed), 10)
         self.assertEqual(mailed[0], 'To: chrism@plope.com')
         self.assertEqual(mailed[1],
-                    'Subject: httpok for http://foo/bar: bad status returned')
+                         'Subject: [%s] httpok for http://foo/bar: bad status returned' % socket.gethostname())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
example:
Subject: [hostname-foo] httpok for http://foo/bar: bad status returned


This can be useful when similar processes run in multiple servers.
