### PR TITLE
process limit not overide by other , group not overide by "any" 

### DIFF
--- a/superlance/memmon.py
+++ b/superlance/memmon.py
@@ -172,13 +172,13 @@ class Memmon:
                         self.stderr.write('RSS of %s is %s\n' % (pname, rss))
                         if  rss > self.programs[name]:
                             self.restart(pname, rss)
-                            continue
+                        continue
 
                 if group in self.groups:
                     self.stderr.write('RSS of %s is %s\n' % (pname, rss))
                     if rss > self.groups[group]:
                         self.restart(pname, rss)
-                        continue
+                    continue
 
                 if self.any is not None:
                     self.stderr.write('RSS of %s is %s\n' % (pname, rss))


### PR DESCRIPTION
Permit to continue to work as expected but permit also to specify one process or one group with a highter memorylimit

 memmon check for process , if a config is specified for , check memory and continue with the next process.
 Thats seems to be strange that specify a specific value for a process can be overide by the "any" value or "group" value

exemple : 
memmon -p proc=600MB -p gp=400MB -a 200MB  
in this case : 
proc can run to 600MB , any or group not restart him
gp can run to 400MB , any  not restart him
every other process are limited to 200MB.

before this commit , "any" restart proc and gp if they run over 200Mb
