### PR TITLE
TimeoutHTTPSConnection fixes

### DIFF
--- a/superlance/timeoutconn.py
+++ b/superlance/timeoutconn.py
@@ -1,5 +1,7 @@
 from superlance.compat import httplib
 import socket
+import ssl
+
 
 class TimeoutHTTPConnection(httplib.HTTPConnection):
     """A customised HTTPConnection allowing a per-connection
@@ -12,7 +14,7 @@ class TimeoutHTTPConnection(httplib.HTTPConnection):
 
         e = "getaddrinfo returns an empty list"
         for res in socket.getaddrinfo(self.host, self.port,
-                0, socket.SOCK_STREAM):
+                                      0, socket.SOCK_STREAM):
             af, socktype, proto, canonname, sa = res
             try:
                 self.sock = socket.socket(af, socktype, proto)
@@ -28,6 +30,7 @@ class TimeoutHTTPConnection(httplib.HTTPConnection):
         if not self.sock:
             raise socket.error(e)
 
+
 class TimeoutHTTPSConnection(httplib.HTTPSConnection):
     timeout = None
 
@@ -36,7 +39,6 @@ class TimeoutHTTPSConnection(httplib.HTTPSConnection):
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if self.timeout:
-            self.sock.settimeout(self.timeout)
+            sock.settimeout(self.timeout)
         sock.connect((self.host, self.port))
-        ssl = socket.ssl(sock, self.key_file, self.cert_file)
-        self.sock = httplib.FakeSocket(sock, ssl)
+        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file)


### PR DESCRIPTION
~~This is basically a replication of #9, which issued 3 years ago but never get merged. I rebased the old revisions onto latest `superlance` and did some PEP8 fix, that's all.~~

~~The reason I want to help it being merged is that I ran into the same problem (`'NoneType' object has no attribute 'settimeout'`). At the beginning I thought to fix it by my own but soon I found someone already did it in #9.~~

This time just try to fix the `'NoneType' object has no attribute 'settimeout'` problem when using `TimeoutHTTPSConnection`.