### PR TITLE
implement #18 Program option

### DIFF
--- a/conftest/README
+++ b/conftest/README
@@ -1,0 +1,9 @@
+To test 
+ - copy crashin fakemail to /R/bin
+ - copy crashmail.conf testcrash.conf testcrash2.conf to /etc/supervisor/conf.d
+
+monitor log files in /L/
+ - You'll get an 'Ignoring hostname: testcrash' message every 10s in /L/crashmail.log (testcrash)
+
+ - You'll get 2 'unexpected exit, mailing' message every 30s in /L/crashmail.log (notifycrash:testcrash2, notifycrash:testcrash3)
+   and the message in /L/fakemail.log

--- a/conftest/crashin
+++ b/conftest/crashin
@@ -1,0 +1,7 @@
+#!/bin/bash
+# test program: non 0 exit code after timeout
+timeout="$1"
+echo $(date) "Crashing in $timeout seconds"
+sleep "$timeout"
+echo $(date) "CRASHING NOW"
+exit 123

--- a/conftest/crashmail.conf
+++ b/conftest/crashmail.conf
@@ -1,0 +1,10 @@
+# config to use the fakemail mail sender
+# and monitor only testcrash2 (crashes every 30s)
+[eventlistener:crashmail]
+command =
+    /usr/local/bin/crashmail
+        -p notifycrash:*
+        -o hostname -m notify-on-crash@domain.com
+        -s '/R/bin/fakemail -t -i -f crash-notifier@domain.com'
+events=PROCESS_STATE_EXITED
+stderr_logfile=/L/crashmail.log

--- a/conftest/fakemail
+++ b/conftest/fakemail
@@ -1,0 +1,6 @@
+#!/bin/bash
+# don't send any mail: only write the args and stdin to the logfile
+logfile=/L/fakemail.log
+echo $(date) "$*" >> "$logfile"
+cat >> "$logfile"
+echo >> "$logfile"

--- a/conftest/testcrash.conf
+++ b/conftest/testcrash.conf
@@ -1,0 +1,9 @@
+# test program: crashes every 10 seconds
+[program:testcrash]
+command=/R/bin/crashin 10
+
+autostart=true
+autorestart=true
+
+stdout_logfile=/L/testcrash.log
+redirect_stderr=true

--- a/conftest/testcrash2.conf
+++ b/conftest/testcrash2.conf
@@ -1,0 +1,21 @@
+[group:notifycrash]
+programs=testcrash2,testcrash3
+
+# test program: crashes every 30 seconds
+[program:testcrash2]
+command=/R/bin/crashin 30
+
+autostart=true
+autorestart=true
+
+stdout_logfile=/L/testcrash2.log
+redirect_stderr=true
+
+[program:testcrash3]
+command=/R/bin/crashin 33
+
+autostart=true
+autorestart=true
+
+stdout_logfile=/L/testcrash3.log
+redirect_stderr=true

--- a/superlance/tests/crashmail_test.py
+++ b/superlance/tests/crashmail_test.py
@@ -1,5 +1,6 @@
 import unittest
 from superlance.compat import StringIO
+import re
 
 class CrashMailTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -29,7 +30,7 @@ class CrashMailTests(unittest.TestCase):
         return prog
 
     def test_runforever_not_process_state_exited(self):
-        programs = {'foo':0, 'bar':0, 'baz_01':0 }
+        programs = []
         any = None
         prog = self._makeOnePopulated(programs, any)
         prog.stdin.write('eventname:PROCESS_STATE len:0\n')
@@ -38,7 +39,7 @@ class CrashMailTests(unittest.TestCase):
         self.assertEqual(prog.stderr.getvalue(), 'non-exited event\n')
 
     def test_runforever_expected_exit(self):
-        programs = ['foo']
+        programs = [re.compile('foo')]
         any = None
         prog = self._makeOnePopulated(programs, any)
         payload=('expected:1 processname:foo groupname:bar '
@@ -51,7 +52,7 @@ class CrashMailTests(unittest.TestCase):
         self.assertEqual(prog.stderr.getvalue(), 'expected exit\n')
 
     def test_runforever_unexpected_exit(self):
-        programs = ['foo']
+        programs = [re.compile('bar:foo')]
         any = None
         prog = self._makeOnePopulated(programs, any)
         payload=('expected:0 processname:foo groupname:bar '
@@ -63,20 +64,53 @@ class CrashMailTests(unittest.TestCase):
         prog.runforever(test=True)
         output = prog.stderr.getvalue()
         lines = output.split('\n')
-        self.assertEqual(lines[0], 'unexpected exit, mailing')
-        self.assertEqual(lines[1], 'Mailed:')
-        self.assertEqual(lines[2], '')
-        self.assertEqual(lines[3], 'To: chrism@plope.com')
-        self.assertTrue('Subject: [foo]: foo crashed at' in lines[4])
-        self.assertEqual(lines[5], '')
+
+        self.assertEqual(lines[1], 'unexpected exit, mailing')
+        self.assertEqual(lines[2], 'Mailed:')
+        self.assertEqual(lines[3], '')
+        self.assertEqual(lines[4], 'To: chrism@plope.com')
+        self.assertTrue('Subject: [foo]: foo crashed at' in lines[5])
+        self.assertEqual(lines[6], '')
         self.assertTrue(
-            'Process foo in group bar exited unexpectedly' in lines[6])
+            'Process foo in group bar exited unexpectedly' in lines[7])
         import os
         f = open(os.path.join(self.tempdir, 'email.log'), 'r')
         mail = f.read()
         f.close()
         self.assertTrue(
             'Process foo in group bar exited unexpectedly' in mail)
+
+    def test_runforever_unexpected_exit_group(self):
+        programs = [re.compile('bar:*')]
+        any = None
+        prog = self._makeOnePopulated(programs, any)
+        payload=('expected:0 processname:foo groupname:bar '
+                 'from_state:RUNNING pid:1')
+        prog.stdin.write(
+            'eventname:PROCESS_STATE_EXITED len:%s\n' % len(payload))
+        prog.stdin.write(payload)
+        prog.stdin.seek(0)
+        prog.runforever(test=True)
+        output = prog.stderr.getvalue()
+        lines = output.split('\n')
+
+        self.assertEqual(lines[1], 'unexpected exit, mailing')
+
+    def test_runforever_unexpected_exit_ignored(self):
+        programs = [re.compile('notfoo')]
+        any = None
+        prog = self._makeOnePopulated(programs, any)
+        payload=('expected:0 processname:foo groupname:bar '
+                 'from_state:RUNNING pid:1')
+        prog.stdin.write(
+            'eventname:PROCESS_STATE_EXITED len:%s\n' % len(payload))
+        prog.stdin.write(payload)
+        prog.stdin.seek(0)
+        prog.runforever(test=True)
+        output = prog.stderr.getvalue()
+        lines = output.split('\n')
+
+        self.assertTrue('ignoring [foo]: foo crashed ' in lines[1])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This branch implements the --program option for crashmail.

It accepts a single program name or a group:program (must use it if program is in a group) or group:\* (to match any program in this group).

Tests have been updated accordingly.

A test config is in conftest.Feel free to remove it if you don't like it.
