### PR TITLE
Embed last 5000 chars from stdout/stderr streams in the email body

### DIFF
--- a/superlance/tests/crashmail_test.py
+++ b/superlance/tests/crashmail_test.py
@@ -22,7 +22,7 @@ class CrashMailTests(unittest.TestCase):
         sendmail = 'cat - > %s' % os.path.join(self.tempdir, 'email.log')
         email = 'chrism@plope.com'
         header = '[foo]'
-        prog = self._makeOne(programs, any, email, sendmail, header)
+        prog = self._makeOne(programs, any, email, sendmail, header, 5000)
         prog.stdin = StringIO()
         prog.stdout = StringIO()
         prog.stderr = StringIO()


### PR DESCRIPTION
IMO, the tail of the process logs can make it easier to debug the crashing applications. 
