### PR TITLE
Fix README for PyPI

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -101,7 +101,7 @@
 
 
 0.5 (2009-05-24)
----------------
+----------------
 
 - Added the ``memmon`` plugin, originally bundled with supervisor and
   now moved to superlance.


### PR DESCRIPTION
PyPI's RST parser is fussy and gives up if you get anything slightly wrong. Fix the missing underline.

Test Plan: Ran `python setup.py check --metadata --restructuredtext`. Before, it output:

```
/usr/local/lib/python2.7/site-packages/setuptools/dist.py:284: UserWarning: Normalizing '1.0.0-dev' to '1.0.0.dev0'
  normalized_version,
running check
warning: check: Title underline too short. (line 106)

warning: check: Title underline too short. (line 106)
```

... and returned non-zero status code. Now it passes with:

```
/usr/local/lib/python2.7/site-packages/setuptools/dist.py:284: UserWarning: Normalizing '1.0.0-dev' to '1.0.0.dev0'
  normalized_version,
running check
```