### PR TITLE
Fix crashmail optionalheader long option

### DIFF
--- a/superlance/crashmail.py
+++ b/superlance/crashmail.py
@@ -153,7 +153,7 @@ def main(argv=sys.argv):
         "any",
         "optionalheader=",
         "sendmail_program=",
-        "email="
+        "email=",
         ]
     arguments = argv[1:]
     try:

--- a/superlance/crashmail.py
+++ b/superlance/crashmail.py
@@ -151,9 +151,9 @@ def main(argv=sys.argv):
         "help",
         "program=",
         "any",
-        "optionalheader="
+        "optionalheader=",
         "sendmail_program=",
-        "email=",
+        "email="
         ]
     arguments = argv[1:]
     try:


### PR DESCRIPTION
This fixes an issue with the `--optionalheader` long option in crashmail. Since the list was missing a comma after the option, `getopt` was parsing the options incorrectly. As an example, I updated [these lines](https://github.com/Supervisor/superlance/blob/master/superlance/crashmail.py#L159-L162) to print the result of `getopt.getopt`:

```python
try:
    opts, args = getopt.getopt(arguments, short_args, long_args)
    print opts
except:
    usage()
```

And ran `crashmail` with the `--optionalheader` long option to see the output:

```bash
$ crashmail --optionalheader=test
[('--optionalheader=sendmail_program', 'test')]
```

Since the option was being parsed as `--optionalheader=sendmail_program`, the [conditional logic to set the `optionalheader` variable](https://github.com/Supervisor/superlance/blob/master/superlance/crashmail.py#L187-L188) was not met.

With these changes, the output looks like this:

```bash
$ crashmail --optionalheader=test
[('--optionalheader', 'test')]
```