### PR TITLE
httpok_emit_logger

### DIFF
--- a/superlance/httpok.py
+++ b/superlance/httpok.py
@@ -61,6 +61,10 @@ Options:
       RUNNING state specified by -p or -a.  This defaults to the
       string, "200".
 
+-C -- specify 'stdout' or 'stderr' for generating PROCESS_COMMUNICATION
+      events from httpok. This needs that the provided stream is placed
+      in the 'capture mode' by setting std{err,out}_capture_maxbytes.
+
 -b -- specify a string which should be present in the body resulting
       from the GET request.  If this string is not present in the
       response, the processes in the RUNNING state specified by -p
@@ -114,7 +118,8 @@ def usage():
 class HTTPOk:
     connclass = None
     def __init__(self, rpc, programs, any, url, timeout, status, inbody,
-                 email, sendmail, coredir, gcore, eager, retry_time):
+                 email, sendmail, coredir, gcore, eager, retry_time,
+                 capture_mode_stream=None):
         self.rpc = rpc
         self.programs = programs
         self.any = any
@@ -131,6 +136,15 @@ class HTTPOk:
         self.stdin = sys.stdin
         self.stdout = sys.stdout
         self.stderr = sys.stderr
+        if capture_mode_stream:
+            if capture_mode_stream == "stderr":
+                self.capture_mode_stream = self.stderr
+            elif capture_mode_stream == "stdout":
+                self.capture_mode_stream = self.stdout
+            else:
+                self.capture_mode_stream = None
+        else:
+            self.capture_mode_stream = None
 
     def listProcesses(self, state=None):
         return [x for x in self.rpc.supervisor.getAllProcessInfo()
@@ -293,13 +307,20 @@ class HTTPOk:
             else:
                 write('%s restarted' % namespec)
 
+            if self.capture_mode_stream:
+                childutils.pcomm.send(str({
+                    'processname': spec.get('name'),
+                    'groupname': spec.get('groupname'),
+                    'pid': spec.get('pid'),
+                }), self.capture_mode_stream)
+
         else:
             write('%s not in RUNNING state, NOT restarting' % namespec)
 
 
 def main(argv=sys.argv):
     import getopt
-    short_args="hp:at:c:b:s:m:g:d:eE"
+    short_args="hp:at:c:b:s:m:g:d:eE:C"
     long_args=[
         "help",
         "program=",
@@ -313,6 +334,7 @@ def main(argv=sys.argv):
         "coredir=",
         "eager",
         "not-eager",
+        "capture-mode="
         ]
     arguments = argv[1:]
     try:
@@ -336,6 +358,7 @@ def main(argv=sys.argv):
     retry_time = 10
     status = '200'
     inbody = None
+    capture_mode_stream = None
 
     for option, value in opts:
 
@@ -375,6 +398,15 @@ def main(argv=sys.argv):
         if option in ('-E', '--not-eager'):
             eager = False
 
+        if option in ('-C', '--capture-mode'):
+            if value in ['stdout', 'stderr']:
+                capture_mode_stream = value.strip()
+            else:
+                capture_mode_stream = None
+                sys.stderr.write('Unable to parse a valid argument.\n')
+                sys.stderr.flush()
+                return
+
     url = arguments[-1]
 
     try:
@@ -388,7 +420,8 @@ def main(argv=sys.argv):
         return
 
     prog = HTTPOk(rpc, programs, any, url, timeout, status, inbody, email,
-                  sendmail, coredir, gcore, eager, retry_time)
+                  sendmail, coredir, gcore, eager, retry_time,
+                  capture_mode_stream)
     prog.runforever()
 
 if __name__ == '__main__':


### PR DESCRIPTION
-C Option specifies the stream onto which httpok will start to emit
messages which would trigger a Process Communication event. Useful for
logging what httpok is doing.

 Default: None