### PR TITLE
Fix a Sphinx warning

### DIFF
--- a/docs/httpok.rst
+++ b/docs/httpok.rst
@@ -118,7 +118,7 @@ Command-Line Syntax
    Disable "eager" monitoring:  do not check the URL or emit mail if no
    monitored process is in the RUNNING state.
 
-.. cmdoption:: <URL>
+.. cmdoption:: URL
 
    The URL to which to issue a GET request.
 


### PR DESCRIPTION
Otherwise, we get:
```
docs/httpok.rst:120: WARNING: Malformed option description u'<URL>', should look like "opt", "-opt args", "--opt args", "/opt args" or "+opt args"
```
