### PR TITLE
Include timezone in memmon's process restarted message

### DIFF
--- a/superlance/memmon.py
+++ b/superlance/memmon.py
@@ -224,10 +224,11 @@ class Memmon:
 
         if self.email and uptime <= self.email_uptime_limit:
             now = time.asctime()
+            timezone = time.strftime('%Z')
             msg = (
-                'memmon.py restarted the process named %s at %s because '
+                'memmon.py restarted the process named %s at %s %s because '
                 'it was consuming too much memory (%s bytes RSS)' % (
-                name, now, rss)
+                name, now, timezone, rss)
                 )
             subject = self.format_subject(
                 'process %s restarted' % name


### PR DESCRIPTION
It would be helpful if the e-mail message from memmon included a time zone. While it's good practice to run servers in UTC, that's not always the case; and it's not always the case that the recipient of the message is in the same time zone as the server throwing the error.