### PR TITLE
Update memmon docs with info about unix_http_server auth

### DIFF
--- a/docs/memmon.rst
+++ b/docs/memmon.rst
@@ -131,6 +131,10 @@ An ``[eventlistener:x]`` section must be placed in :file:`supervisord.conf`
 in order for :command:`memmon` to do its work. See the "Events" chapter in the
 Supervisor manual for more information about event listeners.
 
+In case of using authentication for the unix http server add the environment
+variables SUPERVISOR_USERNAME, SUPERVISOR_PASSWORD and SUPERVISOR_SERVER_URL 
+in the eventlistener section.
+
 The following examples assume that :command:`memmon` is on your system
 :envvar:`PATH`.
 
@@ -193,4 +197,19 @@ The email will only be sent if the process' uptime is less or equal than
    [eventlistener:memmon]
    command=memmon -p foo=200MB -m bob@example.com -u 2d
    events=TICK_60
+
+
+Example Configuration 5 (With Authentication)
+#######################
+
+This configuration is the same as the one in `Example Configuration 1`_ with
+the only difference being that the unix_http_server now requires authentication.
+
+.. code-block:: ini
+
+   [eventlistener:memmon]
+   command=memmon -a 200MB -m bob@example.com
+   environment=SUPERVISOR_USERNAME="<your_username>",SUPERVISOR_PASSWORD="<your_password>",SUPERVISOR_SERVER_URL="<server_url>"
+   events=TICK_60
+
 


### PR DESCRIPTION
I have added the necessary information in the memmon docs to work with unix_http_server authentication