### PR TITLE
Update docs to reflect comma separated to-emails support.

### DIFF
--- a/docs/crashmailbatch.rst
+++ b/docs/crashmailbatch.rst
@@ -28,7 +28,7 @@ Command-Line Syntax
 
 .. cmdoption:: -t <destination email>, --toEmail=<destination email>
    
-   Specify an email address to which crash notification messages are sent.
+   Specify comma separated email addresses to which crash notification messages are sent.
  
 .. cmdoption:: -f <source email>, --fromEmail=<source email>
    

--- a/docs/crashsms.rst
+++ b/docs/crashsms.rst
@@ -26,7 +26,7 @@ Command-Line Syntax
 
 .. cmdoption:: -t <destination email>, --toEmail=<destination email>
    
-   Specify an email address to which crash notification messages are sent.
+   Specify comma separated email addresses to which crash notification messages are sent.
  
 .. cmdoption:: -f <source email>, --fromEmail=<source email>
    

--- a/docs/fatalmailbatch.rst
+++ b/docs/fatalmailbatch.rst
@@ -27,7 +27,7 @@ Command-Line Syntax
 
 .. cmdoption:: -t <destination email>, --toEmail=<destination email>
    
-   Specify an email address to which fatal start notification messages are sent.
+   Specify comma separated email addresses to which fatal start notification messages are sent.
  
 .. cmdoption:: -f <source email>, --fromEmail=<source email>
    

--- a/superlance/crashmailbatch.py
+++ b/superlance/crashmailbatch.py
@@ -37,7 +37,7 @@ Options:
                   This means that all events in each cycle are batched together
                   and sent as a single email
 
---toEmail   - the email address to send alerts to
+--toEmail   - the email address(es) to send alerts to - comma separated
 
 --fromEmail - the email address to send alerts from
 

--- a/superlance/crashsms.py
+++ b/superlance/crashsms.py
@@ -45,7 +45,7 @@ Options:
                  This means that all events in each cycle are batched together
                  and sent as a single email
 
--t,--toEmail   - the email address to send alerts to. Mobile providers
+-t,--toEmail   - the comma separated email addresses to send alerts to. Mobile providers
                  tend to allow sms messages to be sent to their phone numbers
                  via an email address (e.g.: 1234567890@txt.att.net)
 

--- a/superlance/fatalmailbatch.py
+++ b/superlance/fatalmailbatch.py
@@ -39,7 +39,7 @@ Options:
                   This means that all events in each cycle are batched together
                   and sent as a single email
                   
---toEmail   - the email address to send alerts to
+--toEmail   - the email address(es) to send alerts to - comma separated
 
 --fromEmail - the email address to send alerts from
 


### PR DESCRIPTION
comma separated to emails are supported (since [0.7](https://github.com/Supervisor/superlance/blob/5db5ea80bc37d815ce1fcd5fbcbbdd2c2650c03e/CHANGES.txt#L90)?) but not reflected in the docs. This fixes that.