### PR TITLE
Fix broken subject default in crashmailbatch

### DIFF
--- a/superlance/crashmailbatch.py
+++ b/superlance/crashmailbatch.py
@@ -60,7 +60,7 @@ class CrashMailBatch(ProcessStateEmailMonitor):
     process_state_events = ['PROCESS_STATE_EXITED']
 
     def __init__(self, **kwargs):
-        if kwargs['subject'] is None:
+        if kwargs.get('subject') is None:
             kwargs['subject'] = 'Crash alert from supervisord'
         ProcessStateEmailMonitor.__init__(self, **kwargs)
         self.now = kwargs.get('now', None)

--- a/superlance/crashmailbatch.py
+++ b/superlance/crashmailbatch.py
@@ -60,8 +60,8 @@ class CrashMailBatch(ProcessStateEmailMonitor):
     process_state_events = ['PROCESS_STATE_EXITED']
 
     def __init__(self, **kwargs):
-        kwargs['subject'] = kwargs.get('subject',
-                                       'Crash alert from supervisord')
+        if kwargs['subject'] is None:
+            kwargs['subject'] = 'Crash alert from supervisord'
         ProcessStateEmailMonitor.__init__(self, **kwargs)
         self.now = kwargs.get('now', None)
 


### PR DESCRIPTION
Kwargs passed to __init__ from create_from_cmd_line already has 'subject', which is optparse defaulted to None.  Python dict's get method only returns the default arg if the value doesn't exist, not if it exists as None.  This results in default email subjects to actually be None instead of the documented string.