### PR TITLE
Bugfix for #110

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 1.1.0.dev0 (Next Release)
 -------------------------
 
+- Handle edge case for httpok check. If the timeout value is shorter
+  than the time to wait between retries, the httpok check never executed.
+  #110
+
 1.0.0 (2016-10-02)
 ------------------
 

--- a/superlance/httpok.py
+++ b/superlance/httpok.py
@@ -183,8 +183,12 @@ class HTTPOk:
             if self.eager or len(specs) > 0:
 
                 try:
+                    # build a loop value that is guaranteed to execute at least
+                    # once and at most until the timeout is reached and that
+                    # has 0 as the last value (to allow raising an exception
+                    # in the last iteration)
                     for will_retry in range(
-                            self.timeout // (self.retry_time or 1) - 1 ,
+                            (self.timeout - 1) // (self.retry_time or 1),
                             -1, -1):
                         try:
                             headers = {'User-Agent': 'httpok'}


### PR DESCRIPTION
Handle edge case for httpok check. If the timeout value is shorter than
the time to wait between retries, the httpok check never executed.
Also, added a doc string explaining the 'clever' range thing I devised
and didn't understand myself 3 years later.

Closes #110 